### PR TITLE
Adapt AWS Lambda Custom Runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,3 +54,10 @@ $(OUTPUT_DIR)/lambda.zip: $(OUTPUT_DIR)/linux/$(NAME)
 
 .PHONY: lambda-artifact
 lambda-artifact: $(OUTPUT_DIR)/lambda.zip
+
+$(OUTPUT_DIR)/bootstrap.zip: $(OUTPUT_DIR)/linux/$(NAME)
+	mv $(OUTPUT_DIR)/linux/$(NAME) $(OUTPUT_DIR)/linux/bootstrap
+	zip -j $(OUTPUT_DIR)/bootstrap.zip $(OUTPUT_DIR)/linux/bootstrap
+
+.PHONY: lambda-bootstrap-artifact
+labmda-boostrap-artifact: $(OUTPUT_DIR)/bootstrap.zip

--- a/cmd/mackerel-sql-metric-collector/main.go
+++ b/cmd/mackerel-sql-metric-collector/main.go
@@ -96,7 +96,7 @@ func detectExecutorName() string {
 		return e
 
 	}
-	if os.Getenv("AWS_EXECUTION_ENV") != "" {
+	if os.Getenv("AWS_EXECUTION_ENV") != "" || os.Getenv("AWS_LAMBDA_RUNTIME_API") != "" {
 		return lambda.Name
 
 	}


### PR DESCRIPTION
## Why

AWS Lambda's Go runtime is built on Amazon Linux.
However, the Amazon Linux 2-based Go runtime is no longer being developed, and a custom runtime must be used when running on AL2-based.

- https://docs.aws.amazon.com/ja_jp/lambda/latest/dg/lambda-runtimes.html
- https://aws.amazon.com/jp/blogs/compute/migrating-aws-lambda-functions-to-al2/

This program includes support for AWS Lambda.
However, in the custom runtime, the environment variable `AWS_EXECUTION_ENV` used to determine whether to execute on Lambda is not set, so it will not be executed as Lambda and will end with an error.

```
{
  "errorType": "Runtime.ExitError",
  "errorMessage": "RequestId: XXXXXXXX Error: Runtime exited with error: exit status 1"
}
```

## How

- Use also `AWS_LAMBDA_RUNTIME_API` to judge whether it is Lambda or not.
  - https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html#configuration-envvars-runtime
    > AWS_LAMBDA_RUNTIME_API – ([Custom runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtimes-custom.html)) The host and port of the [runtime API](https://docs.aws.amazon.com/lambda/latest/dg/runtimes-api.html). 
- add sample Makefile tasks for using on Custom Runtime
  - With the current definition, only amd64 will be built, but if you modify it here, it will be confusing, so I mimicked and added

## Checks

- After passing the settings that were originally confirmed to be executable, the built artifact is deployed to Lambda and it is confirmed that the execution has been completed successfully.