### PR TITLE
modernize goreleaser config and action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,6 +20,6 @@ jobs:
         uses: goreleaser/goreleaser-action@v4
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,13 +16,12 @@ builds:
       - windows
       - darwin
 archives:
-  - name_template: '{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
-    replacements:
-      darwin: darwin
-      linux: linux
-      windows: windows
-      386: i386
-      amd64: x86_64
+  - name_template: >-
+      {{ .ProjectName }}_
+      {{- .Os }}_
+      {{- if eq .Arch "386" }}i386
+      {{- else if eq .Arch "amd64" }}x86_64
+      {{- else }}{{- .Arch }}{{- if .Arm }}v{{ .Arm }}{{ end }}{{ end }}
     format_overrides:
       - goos: windows
         format: zip

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ BUILD_LDFLAGS := "-X main.revision=$(GIT_REVISION)"
 
 SOURCES = $(shell find . -type f -name '*.go')
 
-all: test $(OUTPUT_DIR)/$(NAME)
+all: $(OUTPUT_DIR)/$(NAME)
 
 .PHONY: lint
 lint:

--- a/release_test.go
+++ b/release_test.go
@@ -1,0 +1,57 @@
+package collector
+
+import (
+	"bytes"
+	"os"
+	"testing"
+	"text/template"
+
+	"gopkg.in/yaml.v2"
+)
+
+// This file contains test cases to check name_template in .goreleaser.yaml generates expected filename.
+
+type releaseConfig struct {
+	Archives []struct {
+		NameTemplate string `yaml:"name_template"`
+	} `yaml:"archives"`
+}
+
+type buildArg struct {
+	ProjectName string
+	Os          string
+	Arch        string
+	Arm         int
+}
+
+func TestReleaseName(t *testing.T) {
+	text, err := os.ReadFile(".goreleaser.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var cfg releaseConfig
+	if err := yaml.Unmarshal(text, &cfg); err != nil {
+		t.Fatal(err)
+	}
+	tmpl, err := template.New("name").Parse(cfg.Archives[0].NameTemplate)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := map[string]buildArg{
+		"pkg_linux_x86_64":   {"pkg", "linux", "amd64", 0},
+		"pkg_linux_i386":     {"pkg", "linux", "386", 0},
+		"pkg_windows_x86_64": {"pkg", "windows", "amd64", 0},
+		"pkg_darwin_arm64":   {"pkg", "darwin", "arm64", 0},
+		"pkg_darwin_armv6":   {"pkg", "darwin", "arm", 6},
+	}
+	for name, arg := range tests {
+		var buf bytes.Buffer
+		if err := tmpl.Execute(&buf, arg); err != nil {
+			t.Fatal(err)
+		}
+		if s := buf.String(); s != name {
+			t.Errorf("Execute(%v) = %s; want %s", arg, s, name)
+		}
+	}
+}


### PR DESCRIPTION
I fixed two deprecation errors.

- `--rm-dist` option
- `archives.replacements` option in **.goreleaser.yaml**