### PR TITLE
Drop building windows binary temporarily

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,10 @@ jobs:
   test:
     strategy:
       matrix:
-        os: ['ubuntu-latest', 'macOS-latest', 'windows-latest']
+        # FIXME: windows builds are broken.
+        # We excludes binaries for windows until fixing that.
+        #os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
+        os: ['ubuntu-latest', 'macos-latest']
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
Windows builds are broken.

We should fix that, but I'm going to create a release next week so I stop windows builds temporarily.