### PR TITLE
fix: generate valid role-session-name

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,7 +39,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.ROLE_TO_ASSUME }}
-          role-session-name: "mackerel-sql-metric-collector:${{ github.run_id }}-${{ github.run_number }}"
+          role-session-name: "mackerel-sql-metric-collector-${{ github.run_id }}-${{ github.run_number }}"
           aws-region: ap-northeast-1
       - name: Login to Public ECR
         uses: docker/login-action@v3


### PR DESCRIPTION
## Why

[The pattern of RoleSessionName](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html#:~:text=length%20of%2064.-,Pattern%3A%20%5B%5Cw%2B%3D%2C.%40%2D%5D*,-Required%3A%20Yes) is `[\w+=,.@-]*`.

## Ref

[Merge pull request #6 from tosuke/push-ecr-public · mackerelio-labs/mackerel-sql-metric-collector@f021783](https://github.com/mackerelio-labs/mackerel-sql-metric-collector/actions/runs/8092347539/job/22112923705)
> Error: Could not assume role with OIDC: 1 validation error detected: Value 'mackerel-sql-metric-collector:8092347539-4' at 'roleSessionName' failed to satisfy constraint: Member must satisfy regular expression pattern: [\w+=,.@-]*