### PR TITLE
feat: default value support

### DIFF
--- a/query/valuekey/query.go
+++ b/query/valuekey/query.go
@@ -77,10 +77,6 @@ func (q *Query) ExecuteWithContext(ctx context.Context, db *sql.DB, logger logr.
 				continue
 			}
 			vs[vk] = value
-
-			if q.KeyPrefix != "" {
-				vk = fmt.Sprintf("%s.%s", q.KeyPrefix, vk)
-			}
 		}
 
 		t := now

--- a/query/valuekey/query_test.go
+++ b/query/valuekey/query_test.go
@@ -21,85 +21,108 @@ func TestMain(m *testing.M) {
 }
 
 func TestQueryExecute(t *testing.T) {
-	logger := stdr.New(log.New(io.Discard, "", 0))
-	db, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatal("sqlmock.New: ", err)
+	t.Parallel()
+	testCases := map[string]struct {
+		query *Query
+		want  []*mackerel.MetricValue
+	}{
+		"basic": {
+			query: &Query{
+				KeyPrefix: "agent",
+				ValueKey: map[string]string{
+					"versions.#{agent_version}": "host_num",
+				},
+				SQL: "SELECT * FROM dummy",
+			},
+			want: []*mackerel.MetricValue{
+				{
+					Name:  "agent.versions.0_1_0",
+					Time:  nowFunc().Unix(),
+					Value: int64(10),
+				},
+			},
+		},
+		"defaultValue": {
+			query: &Query{
+				KeyPrefix: "agent",
+				ValueKey: map[string]string{
+					"versions.#{agent_version}": "host_num",
+				},
+				DefaultValue: map[string]float64{
+					"versions.0_1_1": 0.0,
+				},
+				SQL: "SELECT * FROM dummy",
+			},
+			want: []*mackerel.MetricValue{
+				{
+					Name:  "agent.versions.0_1_0",
+					Time:  nowFunc().Unix(),
+					Value: int64(10),
+				},
+				{
+					Name:  "agent.versions.0_1_1",
+					Time:  nowFunc().Unix(),
+					Value: float64(0.0),
+				},
+			},
+		},
+		"defaultValue_template": {
+			query: &Query{
+				KeyPrefix: "agent",
+				ValueKey: map[string]string{
+					"versions.#{agent_version}": "host_num",
+				},
+				DefaultValue: map[string]float64{
+					"versions.#{agent_version}": 0.0,
+				},
+				SQL: "SELECT * FROM dummy",
+			},
+			want: []*mackerel.MetricValue{
+				{
+					Name:  "agent.versions.0_1_0",
+					Time:  nowFunc().Unix(),
+					Value: int64(10),
+				},
+				{
+					Name:  "agent.versions.0_1_1",
+					Time:  nowFunc().Unix(),
+					Value: float64(0.0),
+				},
+				{
+					Name:  "agent.versions.0_1_2",
+					Time:  nowFunc().Unix(),
+					Value: float64(0.0),
+				},
+			},
+		},
 	}
-	t.Cleanup(func() {
-		db.Close()
-	})
-	columns := []string{"agent_version", "host_num"}
-	mock.ExpectQuery("SELECT (.+) FROM (.+)").WillReturnRows(sqlmock.NewRows(columns).AddRow("0.1.0", 10))
 
-	q := &Query{
-		KeyPrefix: "agent",
-		ValueKey: map[string]string{
-			"versions.#{agent_version}": "host_num",
-		},
-		SQL: "SELECT * FROM dummy",
-	}
-	values, err := q.Execute(db, logger)
-	if err != nil {
-		t.Errorf("Execute: got %v", err)
-	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Errorf("ExpectationsWereMet: got %v", err)
-	}
-	want := []*mackerel.MetricValue{
-		{
-			Name:  "agent.versions.0_1_0",
-			Time:  nowFunc().Unix(),
-			Value: int64(10),
-		},
-	}
-	if diff := cmp.Diff(want, values); diff != "" {
-		t.Errorf("Execute: (-want, +got)\n%s", diff)
-	}
-}
+	for name, tc := range testCases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			logger := stdr.New(log.New(io.Discard, "", 0))
+			db, mock, err := sqlmock.New()
+			if err != nil {
+				t.Fatal("sqlmock.New: ", err)
+			}
+			t.Cleanup(func() {
+				db.Close()
+			})
+			columns := []string{"agent_version", "host_num"}
+			rows := sqlmock.NewRows(columns).AddRow("0.1.0", 10).AddRow("0.1.1", nil).AddRow("0.1.2", nil)
+			mock.ExpectQuery("SELECT (.+) FROM (.+)").WillReturnRows(rows)
 
-func TestQueryWithDefault(t *testing.T) {
-	logger := stdr.New(log.New(io.Discard, "", 0))
-	db, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatal("sqlmock.New: ", err)
-	}
-	t.Cleanup(func() {
-		db.Close()
-	})
-	columns := []string{"agent_version", "host_num"}
-	mock.ExpectQuery("SELECT (.+) FROM (.+)").WillReturnRows(sqlmock.NewRows(columns).AddRow("0.1.0", 10).AddRow("0.1.1", nil).AddRow("0.1.2", nil))
-
-	q := &Query{
-		KeyPrefix: "agent",
-		ValueKey: map[string]string{
-			"versions.#{agent_version}": "host_num",
-		},
-        DefaultValue: map[string]float64{
-            "versions.0_1_1": 0.0,
-        },
-		SQL: "SELECT * FROM dummy",
-	}
-	values, err := q.Execute(db, logger)
-	if err != nil {
-		t.Errorf("Execute: got %v", err)
-	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Errorf("ExpectationsWereMet: got %v", err)
-	}
-	want := []*mackerel.MetricValue{
-		{
-			Name:  "agent.versions.0_1_0",
-			Time:  nowFunc().Unix(),
-			Value: int64(10),
-		},
-        {
-            Name: "agent.versions.0_1_1",
-            Time: nowFunc().Unix(),
-            Value: float64(0.0),
-        },
-	}
-	if diff := cmp.Diff(want, values); diff != "" {
-		t.Errorf("Execute: (-want, +got)\n%s", diff)
+			values, err := tc.query.Execute(db, logger)
+			if err != nil {
+				t.Errorf("Execute: got %v", err)
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Errorf("ExpectationsWereMet: got %v", err)
+			}
+			if diff := cmp.Diff(tc.want, values); diff != "" {
+				t.Errorf("Execute: (-want, +got)\n%s", diff)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Why

For some types of metrics, there is an appropriate default value (for example, the default value for the request count is 0).
It can be useful to set default values as metric values when there are no values for the key.

## What

This PR adds "defaultValue" option to queries.  Check the test for specific instructions for use.